### PR TITLE
Add the second generation system catalog

### DIFF
--- a/internal/catalog/build.go
+++ b/internal/catalog/build.go
@@ -1,0 +1,272 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kyleconroy/dinosql/internal/pg"
+
+	"github.com/davecgh/go-spew/spew"
+	nodes "github.com/lfittl/pg_query_go/nodes"
+)
+
+func ParseRange(rv *nodes.RangeVar) (pg.FQN, error) {
+	fqn := pg.FQN{
+		Schema: "public",
+	}
+	if rv.Catalogname != nil {
+		fqn.Catalog = *rv.Catalogname
+	}
+	if rv.Schemaname != nil {
+		fqn.Schema = *rv.Schemaname
+	}
+	if rv.Relname != nil {
+		fqn.Rel = *rv.Relname
+	} else {
+		return fqn, fmt.Errorf("range has empty relname")
+	}
+	return fqn, nil
+}
+
+func ParseList(list nodes.List) (pg.FQN, error) {
+	parts := stringSlice(list)
+	var fqn pg.FQN
+	switch len(parts) {
+	case 1:
+		fqn = pg.FQN{
+			Catalog: "",
+			Schema:  "public",
+			Rel:     parts[0],
+		}
+	case 2:
+		fqn = pg.FQN{
+			Catalog: "",
+			Schema:  parts[0],
+			Rel:     parts[1],
+		}
+	case 3:
+		fqn = pg.FQN{
+			Catalog: parts[0],
+			Schema:  parts[1],
+			Rel:     parts[2],
+		}
+	default:
+		return fqn, fmt.Errorf("Invalid FQN: %s", join(list, "."))
+	}
+	return fqn, nil
+}
+
+// func getTable(c *pg.Catalog, fqn pg.FQN) (pg.Schema, pg.Table, error) {
+// }
+
+func Update(c *pg.Catalog, stmt nodes.Node) error {
+	if false {
+		spew.Dump(stmt)
+	}
+	raw, ok := stmt.(nodes.RawStmt)
+	if !ok {
+		return fmt.Errorf("expected RawStmt; got %T", stmt)
+	}
+	switch n := raw.Stmt.(type) {
+
+	case nodes.AlterTableStmt:
+		fqn, err := ParseRange(n.Relation)
+		if err != nil {
+			return err
+		}
+		schema, exists := c.Schemas[fqn.Schema]
+		if !exists {
+			return pg.ErrorSchemaDoesNotExist(fqn.Schema)
+		}
+		table, exists := schema.Tables[fqn.Rel]
+		if !exists {
+			return pg.ErrorRelationDoesNotExist(fqn.Rel)
+		}
+
+		for _, cmd := range n.Cmds.Items {
+			switch cmd := cmd.(type) {
+			case nodes.AlterTableCmd:
+				switch cmd.Subtype {
+
+				case nodes.AT_AddColumn:
+					switch d := cmd.Def.(type) {
+					case nodes.ColumnDef:
+						for _, c := range table.Columns {
+							if c.Name == *d.Colname {
+								return pg.ErrorColumnAlreadyExists(table.Name, *d.Colname)
+							}
+						}
+						table.Columns = append(table.Columns, pg.Column{
+							Name:     *d.Colname,
+							DataType: join(d.TypeName.Names, "."),
+							NotNull:  isNotNull(d),
+						})
+					}
+
+				case nodes.AT_DropColumn:
+					removed := false
+					for i, c := range table.Columns {
+						if c.Name == *cmd.Name {
+							table.Columns = append(table.Columns[:i], table.Columns[i+1:]...)
+							removed = true
+						}
+					}
+					if !removed {
+						return pg.ErrorColumnDoesNotExist(table.Name, *cmd.Name)
+					}
+				}
+
+				schema.Tables[fqn.Rel] = table
+			}
+		}
+
+	case nodes.CreateEnumStmt:
+		fqn, err := ParseList(n.TypeName)
+		if err != nil {
+			return err
+		}
+		schema, exists := c.Schemas[fqn.Schema]
+		if !exists {
+			return pg.ErrorSchemaDoesNotExist(fqn.Schema)
+		}
+		if _, exists := schema.Enums[fqn.Rel]; exists {
+			return pg.ErrorTypeAlreadyExists(fqn.Rel)
+		}
+		schema.Enums[fqn.Rel] = pg.Enum{
+			Name: fqn.Rel,
+			Vals: stringSlice(n.Vals),
+		}
+
+	case nodes.CreateStmt:
+		fqn, err := ParseRange(n.Relation)
+		if err != nil {
+			return err
+		}
+		schema, exists := c.Schemas[fqn.Schema]
+		if !exists {
+			return pg.ErrorSchemaDoesNotExist(fqn.Schema)
+		}
+		if _, exists := schema.Tables[fqn.Rel]; exists {
+			return pg.ErrorRelationAlreadyExists(fqn.Rel)
+		}
+		table := pg.Table{
+			Name: fqn.Rel,
+		}
+		for _, elt := range n.TableElts.Items {
+			switch n := elt.(type) {
+			case nodes.ColumnDef:
+				colName := *n.Colname
+				table.Columns = append(table.Columns, pg.Column{
+					Name:     colName,
+					DataType: join(n.TypeName.Names, "."),
+					NotNull:  isNotNull(n),
+				})
+			}
+		}
+		schema.Tables[fqn.Rel] = table
+
+	case nodes.DropStmt:
+		for _, obj := range n.Objects.Items {
+			var fqn pg.FQN
+			var err error
+
+			switch o := obj.(type) {
+			case nodes.List:
+				fqn, err = ParseList(o)
+			case nodes.TypeName:
+				fqn, err = ParseList(o.Names)
+			default:
+				return fmt.Errorf("nodes.DropStmt: unknown node in objects list: %T", o)
+			}
+			if err != nil {
+				return err
+			}
+
+			schema, exists := c.Schemas[fqn.Schema]
+			if !exists {
+				return pg.ErrorSchemaDoesNotExist(fqn.Schema)
+			}
+
+			switch n.RemoveType {
+
+			case nodes.OBJECT_TABLE:
+				if _, exists := schema.Tables[fqn.Rel]; exists {
+					delete(schema.Tables, fqn.Rel)
+				} else if !n.MissingOk {
+					return pg.ErrorRelationDoesNotExist(fqn.Rel)
+				}
+
+			case nodes.OBJECT_TYPE:
+				if _, exists := schema.Enums[fqn.Rel]; exists {
+					delete(schema.Enums, fqn.Rel)
+				} else if !n.MissingOk {
+					return pg.ErrorTypeDoesNotExist(fqn.Rel)
+				}
+
+			}
+		}
+
+	case nodes.RenameStmt:
+		switch n.RenameType {
+		case nodes.OBJECT_TABLE:
+			fqn, err := ParseRange(n.Relation)
+			if err != nil {
+				return err
+			}
+
+			schema, exists := c.Schemas[fqn.Schema]
+			if !exists {
+				return pg.ErrorSchemaDoesNotExist(fqn.Schema)
+			}
+
+			table, exists := schema.Tables[fqn.Rel]
+			if !exists {
+				return pg.ErrorRelationDoesNotExist(fqn.Rel)
+			}
+			if _, exists := schema.Tables[*n.Newname]; exists {
+				return pg.ErrorRelationAlreadyExists(*n.Newname)
+			}
+
+			// Remove the table under the old name
+			delete(schema.Tables, fqn.Rel)
+
+			// Add the table under the new name
+			table.Name = *n.Newname
+			schema.Tables[*n.Newname] = table
+		}
+
+	}
+	return nil
+}
+
+func stringSlice(list nodes.List) []string {
+	items := []string{}
+	for _, item := range list.Items {
+		if n, ok := item.(nodes.String); ok {
+			items = append(items, n.Str)
+		}
+	}
+	return items
+}
+
+func join(list nodes.List, sep string) string {
+	return strings.Join(stringSlice(list), sep)
+}
+
+func isNotNull(n nodes.ColumnDef) bool {
+	if n.IsNotNull {
+		return true
+	}
+	for _, c := range n.Constraints.Items {
+		switch n := c.(type) {
+		case nodes.Constraint:
+			if n.Contype == nodes.CONSTR_NOTNULL {
+				return true
+			}
+			if n.Contype == nodes.CONSTR_PRIMARY {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/catalog/build_test.go
+++ b/internal/catalog/build_test.go
@@ -1,0 +1,240 @@
+package catalog
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/kyleconroy/dinosql/internal/pg"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	query "github.com/lfittl/pg_query_go"
+)
+
+func buildCatalog(stmt string) (pg.Catalog, error) {
+	c := pg.NewCatalog()
+	tree, err := query.Parse(stmt)
+	if err != nil {
+		return c, err
+	}
+	for _, stmt := range tree.Statements {
+		if err := Update(&c, stmt); err != nil {
+			return c, err
+		}
+	}
+	return c, nil
+}
+
+func TestUpdate(t *testing.T) {
+	for i, tc := range []struct {
+		stmt string
+		c    pg.Catalog
+	}{
+		{
+			"CREATE TYPE status AS ENUM ('open', 'closed');",
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Enums: map[string]pg.Enum{
+							"status": pg.Enum{
+								Name: "status",
+								Vals: []string{"open", "closed"},
+							},
+						},
+						Tables: map[string]pg.Table{},
+					},
+				},
+			},
+		},
+		{
+			"CREATE TABLE venues ();",
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Enums: map[string]pg.Enum{},
+						Tables: map[string]pg.Table{
+							"venues": pg.Table{
+								Name: "venues",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			`
+			CREATE TABLE foo ();
+			ALTER TABLE foo ADD COLUMN bar text;
+			ALTER TABLE foo DROP COLUMN bar;
+			`,
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Enums: map[string]pg.Enum{},
+						Tables: map[string]pg.Table{
+							"foo": pg.Table{
+								Name: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			`
+			CREATE TABLE venues ();
+			DROP TABLE venues;
+			`,
+			pg.NewCatalog(),
+		},
+		{
+			`
+			CREATE TYPE status AS ENUM ('open', 'closed');
+			DROP TYPE status;
+			`,
+			pg.NewCatalog(),
+		},
+		{
+			`
+			CREATE TABLE venues ();
+			DROP TABLE IF EXISTS venues;
+			DROP TABLE IF EXISTS venues;
+			`,
+			pg.NewCatalog(),
+		},
+		{
+			`
+			CREATE TYPE status AS ENUM ('open', 'closed');
+			DROP TYPE IF EXISTS status;
+			DROP TYPE IF EXISTS status;
+			`,
+			pg.NewCatalog(),
+		},
+		{
+			`
+			CREATE TABLE venues ();
+			DROP TABLE public.venues;
+			`,
+			pg.NewCatalog(),
+		},
+		{
+			`
+			CREATE TYPE status AS ENUM ('open', 'closed');
+			DROP TYPE public.status;
+			`,
+			pg.NewCatalog(),
+		},
+		{
+			`
+			CREATE TABLE venues ();
+			ALTER TABLE venues RENAME TO arenas;
+			`,
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Enums: map[string]pg.Enum{},
+						Tables: map[string]pg.Table{
+							"arenas": pg.Table{
+								Name: "arenas",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		test := tc
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(test.stmt)
+
+			c, err := buildCatalog(test.stmt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.c, c, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("catalog mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUpdateErrors(t *testing.T) {
+	for i, tc := range []struct {
+		stmt string
+		err  pg.Error
+	}{
+		{
+			`
+			CREATE TABLE foo ();
+			CREATE TABLE foo ();
+			`,
+			pg.Error{Code: "42P07", Message: "relation \"foo\" already exists"},
+		},
+		{
+			`
+			CREATE TYPE foo AS ENUM ('bar');
+			CREATE TYPE foo AS ENUM ('bar');
+			`,
+			pg.Error{Code: "42710", Message: "type \"foo\" already exists"},
+		},
+		{
+			`
+			DROP TABLE foo;
+			`,
+			pg.Error{Code: "42P01", Message: "relation \"foo\" does not exist"},
+		},
+		{
+			`
+			DROP TYPE foo;
+			`,
+			pg.Error{Code: "42704", Message: "type \"foo\" does not exist"},
+		},
+		{
+			`
+			CREATE TABLE foo ();
+			CREATE TABLE bar ();
+			ALTER TABLE foo RENAME TO bar;
+			`,
+			pg.Error{Code: "42P07", Message: "relation \"bar\" already exists"},
+		},
+		{
+			`
+			ALTER TABLE foo RENAME TO bar;
+			`,
+			pg.Error{Code: "42P01", Message: "relation \"foo\" does not exist"},
+		},
+		{
+			`
+			CREATE TABLE foo ();
+			ALTER TABLE foo ADD COLUMN bar text;
+			ALTER TABLE foo ADD COLUMN bar text;
+			`,
+			pg.Error{Code: "42701", Message: "column \"bar\" of relation \"foo\" already exists"},
+		},
+		{
+			`
+			CREATE TABLE foo ();
+			ALTER TABLE foo DROP COLUMN bar;
+			`,
+			pg.Error{Code: "42703", Message: "column \"bar\" of relation \"foo\" does not exist"},
+		},
+	} {
+		test := tc
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(test.stmt)
+			_, err := buildCatalog(test.stmt)
+			if err == nil {
+				t.Fatal("err was nil")
+			}
+
+			var actual pg.Error
+			if err != nil {
+				actual = err.(pg.Error)
+			}
+
+			if diff := cmp.Diff(test.err, actual, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("error mismatch: \n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/pg/catalog.go
+++ b/internal/pg/catalog.go
@@ -1,0 +1,44 @@
+package pg
+
+func NewCatalog() Catalog {
+	return Catalog{
+		Schemas: map[string]Schema{
+			"public": Schema{
+				Tables: map[string]Table{},
+				Enums:  map[string]Enum{},
+			},
+		},
+	}
+}
+
+type FQN struct {
+	Catalog string
+	Schema  string
+	Rel     string
+}
+
+type Catalog struct {
+	Schemas map[string]Schema
+}
+
+type Schema struct {
+	Name   string
+	Tables map[string]Table
+	Enums  map[string]Enum
+}
+
+type Table struct {
+	Name    string
+	Columns []Column
+}
+
+type Column struct {
+	Name     string
+	DataType string
+	NotNull  bool
+}
+
+type Enum struct {
+	Name string
+	Vals []string
+}

--- a/internal/pg/errors.go
+++ b/internal/pg/errors.go
@@ -1,0 +1,66 @@
+package pg
+
+import "fmt"
+
+type Error struct {
+	Message string
+	Code    string
+	Hint    string
+}
+
+func (e Error) Error() string {
+	return e.Message
+}
+
+func ErrorColumnAlreadyExists(rel, col string) Error {
+	return Error{
+		Code:    "42701",
+		Message: fmt.Sprintf("column \"%s\" of relation \"%s\" already exists", col, rel),
+	}
+}
+
+func ErrorColumnDoesNotExist(rel, col string) Error {
+	return Error{
+		Code:    "42703",
+		Message: fmt.Sprintf("column \"%s\" of relation \"%s\" does not exist", col, rel),
+	}
+}
+
+func ErrorRelationAlreadyExists(rel string) Error {
+	return Error{
+		Code:    "42P07",
+		Message: fmt.Sprintf("relation \"%s\" already exists", rel),
+	}
+}
+
+func ErrorRelationDoesNotExist(tbl string) Error {
+	return Error{
+		Code:    "42P01",
+		Message: fmt.Sprintf("relation \"%s\" does not exist", tbl),
+	}
+}
+
+func ErrorSchemaDoesNotExist(sch string) Error {
+	return Error{
+		Code:    "3F000",
+		Message: fmt.Sprintf("schema \"%s\" does not exist", sch),
+	}
+}
+
+func ErrorTypeAlreadyExists(typ string) Error {
+	return Error{
+		Code:    "42710",
+		Message: fmt.Sprintf("type \"%s\" already exists", typ),
+	}
+}
+
+func ErrorTypeDoesNotExist(typ string) Error {
+	return Error{
+		Code:    "42704",
+		Message: fmt.Sprintf("type \"%s\" does not exist", typ),
+	}
+}
+
+// severity: ERROR
+// code: 42701
+// message: column "bar" of relation "foo" already exists


### PR DESCRIPTION
The main goal of the new catalog package is to contain less information. The current `postgres` package has too much information about things, such as `GoName` and `GoType`. 

Long term, I'd like to be able to build out `pg.Catalog` both from SQL and a live database.