### PR TITLE
Add support for cast operations

### DIFF
--- a/internal/catalog/build.go
+++ b/internal/catalog/build.go
@@ -379,3 +379,14 @@ func isNotNull(n nodes.ColumnDef) bool {
 	}
 	return false
 }
+
+func ToColumn(n *nodes.TypeName) pg.Column {
+	if n == nil {
+		panic("can't build column for nil type name")
+	}
+	return pg.Column{
+		DataType: join(n.Names, "."),
+		NotNull:  true, // XXX: How do we know if this should be null?
+		IsArray:  isArray(n),
+	}
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -10,19 +10,19 @@ import (
 
 	"github.com/kyleconroy/dinosql/internal/dinosql"
 
+	"github.com/davecgh/go-spew/spew"
+	pg "github.com/lfittl/pg_query_go"
 	"github.com/spf13/cobra"
 )
 
 // Do runs the command logic.
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
-	rootCmd := &cobra.Command{
-		Use:          "dinosql",
-		SilenceUsage: true,
-	}
-	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(initCmd)
-	rootCmd.AddCommand(genCmd)
+	rootCmd := &cobra.Command{Use: "dinosql", SilenceUsage: true}
 	rootCmd.AddCommand(checkCmd)
+	rootCmd.AddCommand(genCmd)
+	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(parseCmd)
+	rootCmd.AddCommand(versionCmd)
 
 	rootCmd.SetArgs(args)
 	rootCmd.SetIn(stdin)
@@ -43,7 +43,26 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the DinoSQL version number",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v1.0.0")
+		fmt.Println("v0.0.1")
+	},
+}
+
+var parseCmd = &cobra.Command{
+	Use:   "parse",
+	Short: "Parse and print the AST for a SQL file",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, filename := range args {
+			blob, err := ioutil.ReadFile(filename)
+			if err != nil {
+				return err
+			}
+			tree, err := pg.Parse(string(blob))
+			if err != nil {
+				return err
+			}
+			spew.Dump(tree)
+		}
+		return nil
 	},
 }
 

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -362,6 +362,32 @@ func TestQueries(t *testing.T) {
 				},
 			},
 		},
+		{
+			"select text array",
+			`
+			SELECT $1::TEXT[];
+			`,
+			Query{
+				Columns: []core.Column{
+					{Name: "", DataType: "text", IsArray: true, NotNull: true},
+				},
+				Params: []Parameter{
+					{1, core.Column{Name: "", DataType: "text", NotNull: true, IsArray: true}},
+				},
+			},
+		},
+		{
+			"select column cast",
+			`
+			CREATE TABLE foo (bar bool not null);
+			SELECT bar::int FROM foo;
+			`,
+			Query{
+				Columns: []core.Column{
+					{Name: "bar", DataType: "pg_catalog.int4", NotNull: true},
+				},
+			},
+		},
 	} {
 		test := tc
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This change gets us closer to generating the ideal code for the query @srenatus posted in #7. Currently, the output looks like:

```go
const deleteToken = `-- name: DeleteToken :exec
DELETE FROM chef_authn_tokens cat
WHERE cat.id=$1
AND projects_match(cat.project_ids, $2::TEXT[])
`

type DeleteTokenParams struct {
        ID      string
        Dollar2 []string
}

func (q *Queries) DeleteToken(ctx context.Context, arg DeleteTokenParams) error {
        _, err := q.db.ExecContext(ctx, deleteToken, arg.ID, pq.Array(arg.Dollar2))
        return err
}
```