### PR TITLE
A smorgasbord of fixes

### DIFF
--- a/internal/catalog/build_test.go
+++ b/internal/catalog/build_test.go
@@ -151,6 +151,24 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			`
+			CREATE TABLE foo (bar text NOT NULL);
+			ALTER TABLE foo ALTER COLUMN bar DROP NOT NULL;
+			`,
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Tables: map[string]pg.Table{
+							"foo": pg.Table{
+								Name:    "foo",
+								Columns: []pg.Column{{Name: "bar", DataType: "text"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			`
 			CREATE TABLE foo (bar text);
 			ALTER TABLE foo RENAME bar TO baz;
 			`,

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -418,7 +418,11 @@ func (r Result) goInnerType(columnType string, notNull bool) string {
 		return "int32"
 
 	case "bigserial", "pg_catalog.serial8":
-		return "int64"
+		if notNull {
+			return "int64"
+		} else {
+			return "sql.NullInt64"
+		}
 
 	case "smallserial", "pg_catalog.serial2":
 		return "int16"
@@ -427,7 +431,11 @@ func (r Result) goInnerType(columnType string, notNull bool) string {
 		return "int32"
 
 	case "bigint", "pg_catalog.int8":
-		return "int64"
+		if notNull {
+			return "int64"
+		} else {
+			return "sql.NullInt64"
+		}
 
 	case "smallint", "pg_catalog.int2":
 		return "int16"

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -538,10 +538,18 @@ func (r Result) GoQueries() []GoQuery {
 		// TODO: Will horribly break sometimes
 		if query.NeedsEdit {
 			var cols []string
+			find := "*"
 			for _, c := range query.Columns {
-				cols = append(cols, c.Name)
+				if c.Scope != "" {
+					find = c.Scope + ".*"
+				}
+				name := c.Name
+				if c.Scope != "" {
+					name = c.Scope + "." + name
+				}
+				cols = append(cols, name)
 			}
-			code = strings.Replace(query.SQL, "*", strings.Join(cols, ", "), 1)
+			code = strings.Replace(query.SQL, find, strings.Join(cols, ", "), 1)
 		}
 
 		gq := GoQuery{

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -560,23 +560,15 @@ func (r Result) GoQueries() []GoQuery {
 				typ:  r.goType(p.Column),
 			}
 		} else if len(query.Params) > 1 {
-			val := GoQueryValue{
-				Emit: true,
-				Name: "arg",
-				Struct: &GoStruct{
-					Name: gq.MethodName + "Params",
-				},
-			}
+			var cols []core.Column
 			for _, p := range query.Params {
-				val.Struct.Fields = append(val.Struct.Fields, GoField{
-					Name: r.structName(paramName(p)),
-					Type: r.goType(p.Column),
-					Tags: map[string]string{
-						"json": p.Column.Name,
-					},
-				})
+				cols = append(cols, p.Column)
 			}
-			gq.Arg = val
+			gq.Arg = GoQueryValue{
+				Emit:   true,
+				Name:   "arg",
+				Struct: r.columnsToStruct(gq.MethodName+"Params", cols),
+			}
 		}
 
 		if len(query.Columns) == 1 {

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -385,6 +385,7 @@ func outputColumns(c core.Catalog, node nodes.Node) ([]core.Column, error) {
 			switch {
 			case HasStarRef(n):
 				for _, t := range tables {
+					scope := join(n.Fields, ".")
 					if scope != "" && scope != t.Name {
 						continue
 					}

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -370,7 +370,7 @@ func outputColumns(c core.Catalog, node nodes.Node) ([]core.Column, error) {
 		switch n := res.Val.(type) {
 
 		case nodes.A_Expr:
-			name := "_"
+			name := ""
 			if res.Name != nil {
 				name = *res.Name
 			}

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -396,6 +396,7 @@ func outputColumns(c core.Catalog, node nodes.Node) ([]core.Column, error) {
 						}
 						cols = append(cols, core.Column{
 							Name:     cname,
+							Scope:    scope,
 							DataType: c.DataType,
 							NotNull:  c.NotNull,
 							IsArray:  c.IsArray,

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -290,7 +290,15 @@ func sourceTables(c core.Catalog, node nodes.Node) ([]core.Table, error) {
 		}
 	case nodes.SelectStmt:
 		with = n.WithClause
-		list = n.FromClause
+		for _, from := range n.FromClause.Items {
+			switch n := from.(type) {
+			case nodes.JoinExpr:
+				list.Items = append(list.Items, n.Larg)
+				list.Items = append(list.Items, n.Rarg)
+			default:
+				list.Items = append(list.Items, n)
+			}
+		}
 	default:
 		return nil, fmt.Errorf("sourceTables: unsupported node type: %T", n)
 	}

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -240,7 +240,7 @@ func TestQueries(t *testing.T) {
 			Query{
 				Columns: []core.Column{
 					{Name: "city", DataType: "text", NotNull: true},
-					{Name: "count", DataType: "bigint"},
+					{Name: "count", DataType: "bigint", NotNull: true},
 				},
 			},
 		},
@@ -285,8 +285,8 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Columns: []core.Column{
-					{Name: "count", DataType: "bigint", NotNull: false},
-					{Name: "count", DataType: "bigint", NotNull: false},
+					{Name: "count", DataType: "bigint", NotNull: true},
+					{Name: "count", DataType: "bigint", NotNull: true},
 				},
 			},
 		},
@@ -305,7 +305,7 @@ func TestQueries(t *testing.T) {
 					{1, core.Column{Name: "ready", DataType: "bool", NotNull: true}},
 				},
 				Columns: []core.Column{
-					{Name: "count", DataType: "bigint"},
+					{Name: "count", DataType: "bigint", NotNull: true},
 				},
 			},
 		},
@@ -314,6 +314,19 @@ func TestQueries(t *testing.T) {
 			`
 			CREATE TABLE foo (name text not null, slug text not null);
 			UPDATE foo SET name = $2 WHERE slug = $1;
+			`,
+			Query{
+				Params: []Parameter{
+					{1, core.Column{Name: "slug", DataType: "text", NotNull: true}},
+					{2, core.Column{Name: "name", DataType: "text", NotNull: true}},
+				},
+			},
+		},
+		{
+			"update_set_multiple",
+			`
+			CREATE TABLE foo (name text not null, slug text not null);
+			UPDATE foo SET (name, slug) = ($2, $1);
 			`,
 			Query{
 				Params: []Parameter{

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -436,13 +436,13 @@ func TestQueries(t *testing.T) {
 			`
 			CREATE TABLE foo (barid serial not null);
 			CREATE TABLE bar (id serial not null, owner text not null);
-			SELECT owner FROM foo
+			SELECT foo.* FROM foo
 			JOIN bar ON bar.id = barid
 			WHERE owner = $1;
 			`,
 			Query{
 				Columns: []core.Column{
-					{Name: "owner", DataType: "text", NotNull: true},
+					{Name: "barid", DataType: "serial", NotNull: true},
 				},
 				Params: []Parameter{
 					{1, core.Column{Name: "owner", DataType: "text", NotNull: true}},

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -431,6 +431,24 @@ func TestQueries(t *testing.T) {
 				},
 			},
 		},
+		{
+			"join where clause",
+			`
+			CREATE TABLE foo (barid serial not null);
+			CREATE TABLE bar (id serial not null, owner text not null);
+			SELECT owner FROM foo
+			JOIN bar ON bar.id = barid
+			WHERE owner = $1;
+			`,
+			Query{
+				Columns: []core.Column{
+					{Name: "owner", DataType: "text", NotNull: true},
+				},
+				Params: []Parameter{
+					{1, core.Column{Name: "owner", DataType: "text", NotNull: true}},
+				},
+			},
+		},
 	} {
 		test := tc
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -478,7 +478,7 @@ func TestComparisonOperators(t *testing.T) {
 			}
 			expected := Query{
 				Columns: []core.Column{
-					{Name: "_", DataType: "bool", NotNull: true},
+					{Name: "", DataType: "bool", NotNull: true},
 				},
 			}
 			if diff := cmp.Diff(expected, q); diff != "" {

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -442,7 +442,7 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Columns: []core.Column{
-					{Name: "barid", DataType: "serial", NotNull: true},
+					{Name: "barid", DataType: "serial", NotNull: true, Scope: "foo"},
 				},
 				Params: []Parameter{
 					{1, core.Column{Name: "owner", DataType: "text", NotNull: true}},

--- a/internal/dinosql/soup.go
+++ b/internal/dinosql/soup.go
@@ -723,7 +723,9 @@ func Walk(f Visitor, node nodes.Node) {
 		walkn(f, n.Rarg)
 		walkn(f, n.UsingClause)
 		walkn(f, n.Quals)
-		walkn(f, n.Alias)
+		if n.Alias != nil {
+			walkn(f, *n.Alias)
+		}
 
 	case nodes.List:
 		for _, item := range n.Items {

--- a/internal/pg/catalog.go
+++ b/internal/pg/catalog.go
@@ -83,6 +83,9 @@ type Column struct {
 	DataType string
 	NotNull  bool
 	IsArray  bool
+
+	// XXX: Figure out what PostgreSQL calls `foo.id`
+	Scope string
 }
 
 type Enum struct {


### PR DESCRIPTION
- Add initial support for JOIN queries. Fixes #27
- Use `sql.NullInt64` for null bigint columns
- Correctly expand `table.*` column names in queries
- Support multi-assignement UPDATE statements
